### PR TITLE
Implement --to-clipboard for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ tempfile = "3.1.0"
 conv = "0.3.3"
 euclid = "0.20"
 log = "0.4.8"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 pasteboard = "0.1.1"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tempfile = "3.1.0"
 conv = "0.3.3"
 euclid = "0.20"
 log = "0.4.8"
+pasteboard = "0.1.1"
 
 [lib]
 name = "silicon"


### PR DESCRIPTION
* The pasteboard crate has been added to Cargo.toml.
* In src/bin, use of this crate is conditional on target_os = "macOS"
* The implementation of dump_image_to_clipboard is exactly like the linux one, except instead of shelling out to xclip, we call the unsafe function:

```rust
Pasteboard::Image.copy(temp.path().to_str().unwrap());
```

Hat tip to @segeljakt for pasteboard :)

Here's a short [screen capture](https://youbeill.in/scrap/czechization-apprenticehood-dotant-consubstantive/silicon-to-clipboard.mp4) demonstrating this change.

... I'll also mention that I've never written a single line of Rust prior to this, so hopefully I haven't done something terrible. "Works for me", though :)