### PR TITLE
Create parent directories for image path

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -7,6 +7,7 @@ use crate::config::Config;
 use crate::utils::*;
 use failure::Error;
 use image::DynamicImage;
+use std::fs;
 use structopt::StructOpt;
 use syntect::easy::HighlightLines;
 use syntect::util::LinesWithEndings;
@@ -85,6 +86,19 @@ fn run() -> Result<(), Error> {
         dump_image_to_clipboard(&image)?;
     } else {
         let path = config.get_expanded_output().unwrap();
+
+        if let Some(parent) = path.parent() {
+            if !parent.is_dir() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    format_err!(
+                        "Failed to create parent directories for path {}: {}",
+                        path.display(),
+                        e
+                    )
+                })?;
+            }
+        }
+
         image
             .save(&path)
             .map_err(|e| format_err!("Failed to save image to {}: {}", path.display(), e))?;


### PR DESCRIPTION
Before saving image to file, create all directories leading up to
the file path's parent directory, if it doesn't exist already.

__(My) use-case:__
I use `silicon` with [`vim-silicon`], which has an option to set the output directory via config,
where you can interpolate the current date/time into the file path.
I want it to create a directory with the current date, and place the generated image in that directory.
So I want the output path to be something like this ...
```
"~/Screenshots/Silicon/<DATE>/image.png"
```
... where the `<DATE>` part would be a new directory.
This PR makes `silicon` create the path leading up to `<DATE>`.

---

I'm not sure if this PR should really belong in `silicon`, to be honest.
Because of my use-case, this should probably be done in [`vim-silicon`],
but I don't know vimscript and I do know rust :)

Feel free to not merge this, if you don't see it fit.
Or maybe we could add a command-line flag that enables this feature?

[`vim-silicon`]: https://github.com/segeljakt/vim-silicon