### PR TITLE
Added support for --to-clipboard in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /.idea
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-code 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "str-buf 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +394,15 @@ dependencies = [
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-code"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "str-buf 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1156,6 +1175,7 @@ name = "silicon"
 version = "0.3.2"
 dependencies = [
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clipboard-win 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1169,6 +1189,11 @@ dependencies = [
  "syntect 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "str-buf"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -1448,6 +1473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
 "checksum clipboard-win 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+"checksum clipboard-win 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc29d3daea60dabda924ff1d6f9dbf9f6563e9edb851cbc8cf9bb264ba29f33"
 "checksum cmake 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 "checksum cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f29f7768b2d1be17b96158e3285951d366b40211320fb30826a76cb7a0da6400"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
@@ -1472,6 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dwrote 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+"checksum error-code 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6744173039038c64bbf51b45a20d83afb758ed059c32d26594da04c13428f47f"
 "checksum expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
 "checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 "checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
@@ -1562,6 +1589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 "checksum servo-fontconfig 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b47fef69c52fb55838c756949c60595f0b855daa4e82fc52ad99ff3e03e2c70"
 "checksum servo-fontconfig-sys 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+"checksum str-buf 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cec4d70d0ed9214ae8d642a13bafe4fdfe45a4c611d27a9fb4d4c1a3b02a12e3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pasteboard = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 clipboard-win = "4.0.2"
-image = { version = "0.23", default-features = false, features = ["jpeg", "bmp", "jpeg_rayon", "png"] }
+image = { version = "0.23", default-features = false, features = ["jpeg", "bmp", "jpeg_rayon"] }
 
 [dependencies.image]
 version = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ log = "0.4.11"
 [target.'cfg(target_os = "macos")'.dependencies]
 pasteboard = "0.1.1"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+clipboard-win = "4.0.2"
+
 [dependencies.image]
 version = "0.23"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ pasteboard = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 clipboard-win = "4.0.2"
+image = { version = "0.23", default-features = false, features = ["jpeg", "bmp", "jpeg_rayon", "png"] }
 
 [dependencies.image]
 version = "0.23"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -65,11 +65,11 @@ pub fn dump_image_to_clipboard(image: &DynamicImage) -> Result<(), Error> {
     image.write_to(&mut temp, ImageOutputFormat::Bmp)?;
 
     let _clip =
-        Clipboard::new_attempts(10).map_err(|e| format_err!("Couldn't open clipboard: {}", e));
+        Clipboard::new_attempts(10).map_err(|e| format_err!("Couldn't open clipboard: {}", e))?;
 
     formats::Bitmap
         .write_clipboard(&temp)
-        .map_err(|e| format_err!("Failed copy image: {}", e));
+        .map_err(|e| format_err!("Failed copy image: {}", e))?;
     Ok(())
 }
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -10,12 +10,15 @@ use image::DynamicImage;
 use structopt::StructOpt;
 use syntect::easy::HighlightLines;
 use syntect::util::LinesWithEndings;
+#[cfg(target_os = "windows")]
+use {
+    clipboard_win::{formats::RawData, set_clipboard},
+    image::ImageOutputFormat,
+};
 #[cfg(target_os = "macos")]
 use {image::ImageOutputFormat, pasteboard::Pasteboard};
 #[cfg(target_os = "linux")]
 use {image::ImageOutputFormat, std::process::Command};
-#[cfg(target_os = "windows")]
-use {image::ImageOutputFormat, clipboard_win::{set_clipboard, formats::RawData}};
 
 pub mod blur;
 pub mod config;


### PR DESCRIPTION
Add the option to do `--to-clipboard` in Windows. Based on the impl made in https://github.com/Aloxaf/silicon/pull/99
Windows Bitmap doesn't support transparency so it was neccesary to convert it to RGB then to BMP.

[Here's a short demo!](https://streamable.com/612mb3)