### PR TITLE
Support background images

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::formatter::{ImageFormatter, ImageFormatterBuilder};
-use crate::utils::{ShadowAdder, ToRgba};
+use crate::utils::{Background, ShadowAdder, ToRgba};
 use anyhow::Error;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use image::Rgba;
@@ -55,6 +55,9 @@ type Lines = Vec<u32>;
 #[derive(StructOpt, Debug)]
 #[structopt(name = "silicon")]
 pub struct Config {
+    /// Background image
+    #[structopt(long, conflicts_with = "background")]
+    pub background_image: Option<PathBuf>,
     /// Background color of the image
     #[structopt(
         long,
@@ -234,7 +237,10 @@ impl Config {
 
     pub fn get_shadow_adder(&self) -> ShadowAdder {
         ShadowAdder::new()
-            .background(self.background)
+            .background(match &self.background_image {
+                Some(path) => Background::Image(image::open(path).unwrap().to_rgba()),
+                None => Background::Solid(self.background),
+            })
             .shadow_color(self.shadow_color)
             .blur_radius(self.shadow_blur_radius)
             .pad_horiz(self.pad_horiz)

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,17 +228,17 @@ impl Config {
             .font(self.font.clone().unwrap_or_default())
             .round_corner(!self.no_round_corner)
             .window_controls(!self.no_window_controls)
-            .shadow_adder(self.get_shadow_adder())
+            .shadow_adder(self.get_shadow_adder()?)
             .tab_width(self.tab_width)
             .highlight_lines(self.highlight_lines.clone().unwrap_or_default());
 
         Ok(formatter.build()?)
     }
 
-    pub fn get_shadow_adder(&self) -> ShadowAdder {
-        ShadowAdder::new()
+    pub fn get_shadow_adder(&self) -> Result<ShadowAdder, Error> {
+        Ok(ShadowAdder::new()
             .background(match &self.background_image {
-                Some(path) => Background::Image(image::open(path).unwrap().to_rgba()),
+                Some(path) => Background::Image(image::open(path)?.to_rgba()),
                 None => Background::Solid(self.background),
             })
             .shadow_color(self.shadow_color)
@@ -246,7 +246,7 @@ impl Config {
             .pad_horiz(self.pad_horiz)
             .pad_vert(self.pad_vert)
             .offset_x(self.shadow_offset_x)
-            .offset_y(self.shadow_offset_y)
+            .offset_y(self.shadow_offset_y))
     }
 
     pub fn get_expanded_output(&self) -> Option<PathBuf> {


### PR DESCRIPTION
This PR adds support for using images as a background
- Added `--background-image` option, it is a path to the background image
- Image is currently resized to fit (doesn't preserve aspect ratio)
- Takes 2.5 seconds with a 6000x4000 image (500ms with solid color), maybe there's a way to make it faster
- I'm a Rust newbie so my code can be bad, please let me know if there's a way to make it better