### PR TITLE
Bump pasteboard dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 shell-words = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-pasteboard = "0.1.1"
+pasteboard = "0.1.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 clipboard-win = "4.0.2"


### PR DESCRIPTION
This makes it build on macOS Big Sur (and consequently, M1 Macs).