### PR TITLE
docs: add dependency for Fedora 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ sudo apt install libxml2-dev
 sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev
 ```
 
+### Fedora
+```bash
+sudo dnf install cmake expat-devel libxcb-devel freetype-devel libxml2-devel
+```
+
 ### Arch Linux
 
 ```bash


### PR DESCRIPTION
I tried to install silicon on my Fedora machine.
I found that the below dependency are required for successful installation on Fedora 33.

```bash
sudo dnf install cmake expat-devel libxcb-devel freetype-devel libxml2-devel
```