### PR TITLE
Support font ligatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfbuzz-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8c27ca13930dc4ffe474880040fe9e0f03c2121600dc9c95423624cab3e467"
+dependencies = [
+ "cc",
+ "core-graphics",
+ "core-text",
+ "foreign-types",
+ "freetype",
+ "pkg-config",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1315,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "font-kit",
+ "harfbuzz-sys",
  "image",
  "imageproc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 dirs = "3.0"
 imageproc = "0.22.0"
-font-kit = "0.10"
 clipboard = "0.5.0"
 tempfile = "3.1.0"
 conv = "0.3.3"
@@ -54,6 +53,13 @@ version = "0.8.2"
 default-features = false
 features = ["termcolor", "atty", "humantime"]
 optional = true
+
+[dependencies.font-kit]
+version= "0.10"
+features= ["loader-freetype-default", "source-fontconfig-default"]
+
+[dependencies.harfbuzz-sys]
+version="0.5.0"
 
 [patch.crates-io]
 pathfinder_simd = { version = "0.5.0", git = "https://github.com/servo/pathfinder" }

--- a/src/hb_wrapper.rs
+++ b/src/hb_wrapper.rs
@@ -1,0 +1,117 @@
+use anyhow::{ensure, Result};
+use core::slice;
+// font_kit already has a wrapper around freetype called Font so use it directly
+use font_kit::font::Font;
+use font_kit::loaders::freetype::NativeFont;
+// use harfbuzz for shaping ligatures
+pub use harfbuzz::*;
+use harfbuzz_sys as harfbuzz;
+use std::mem;
+
+/// font feature tag
+pub fn feature_from_tag(tag: &str) -> Result<hb_feature_t> {
+    unsafe {
+        let mut feature = mem::zeroed();
+        ensure!(
+            hb_feature_from_string(
+                tag.as_ptr() as *const i8,
+                tag.len() as i32,
+                &mut feature as *mut _
+            ) != 0,
+            "hb_feature_from_string failed for {}",
+            tag
+        );
+        Ok(feature)
+    }
+}
+
+/// Harfbuzz font
+pub struct HBFont {
+    font: *mut hb_font_t,
+}
+
+// harfbuzz freetype integration
+extern "C" {
+    pub fn hb_ft_font_create_referenced(face: NativeFont) -> *mut hb_font_t; // the same as hb_face_t
+}
+
+impl Drop for HBFont {
+    fn drop(&mut self) {
+        unsafe { hb_font_destroy(self.font) }
+    }
+}
+
+impl HBFont {
+    pub fn new(face: &Font) -> HBFont {
+        HBFont {
+            font: unsafe { hb_ft_font_create_referenced(face.native_font() as _) },
+        }
+    }
+    pub fn shape(&mut self, buffer: &HBBuffer, features: &[hb_feature_t]) {
+        unsafe {
+            hb_shape(
+                self.font,
+                buffer.buffer,
+                features.as_ptr(),
+                features.len() as u32,
+            );
+        }
+    }
+}
+
+/// Harfbuzz buffer
+pub struct HBBuffer {
+    buffer: *mut hb_buffer_t,
+}
+
+impl Drop for HBBuffer {
+    fn drop(&mut self) {
+        unsafe { hb_buffer_destroy(self.buffer) }
+    }
+}
+
+impl HBBuffer {
+    pub fn new() -> Result<HBBuffer> {
+        let hb_buf = unsafe { hb_buffer_create() };
+        ensure!(
+            unsafe { hb_buffer_allocation_successful(hb_buf) } != 0,
+            "hb_buffer_create failed!"
+        );
+        Ok(HBBuffer { buffer: hb_buf })
+    }
+
+    pub fn guess_segments_properties(&mut self) {
+        unsafe { hb_buffer_guess_segment_properties(self.buffer) };
+    }
+
+    pub fn add_utf8(&mut self, s: &[u8]) {
+        unsafe {
+            hb_buffer_add_utf8(
+                self.buffer,
+                s.as_ptr() as *const i8,
+                s.len() as i32,
+                0,
+                s.len() as i32,
+            );
+        }
+    }
+    pub fn add_str(&mut self, s: &str) {
+        self.add_utf8(s.as_bytes());
+    }
+
+    pub fn get_glyph_infos(&mut self) -> &[hb_glyph_info_t] {
+        unsafe {
+            let mut len: u32 = 0;
+            let info = hb_buffer_get_glyph_infos(self.buffer, &mut len as *mut u32);
+            slice::from_raw_parts(info, len as usize)
+        }
+    }
+
+    pub fn get_glyph_positions(&mut self) -> &[hb_glyph_position_t] {
+        unsafe {
+            let mut len: u32 = 0;
+            let info = hb_buffer_get_glyph_positions(self.buffer, &mut len as *mut u32);
+            slice::from_raw_parts(info, len as usize)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,4 +39,5 @@ pub mod directories;
 pub mod error;
 pub mod font;
 pub mod formatter;
+pub mod hb_wrapper;
 pub mod utils;


### PR DESCRIPTION
close #102 
Support monospace ligatures by including `harfbuzz`.

To render font features like ligature, it's required to use a font shaping engine. Here I use Harfbuzz for both shaping and cross-platform. So instead of writing the same logic using platform-specific shaping engine which I am also unfamiliar with, I just need to write a simple wrapper around `harfbuzz-sys` in `hb_wrapper.rs`.

Notice that I also enforce the use of `freetype` feature for `font-kit` as `font-kit` would use platform-specific rasterization library by default which would breaks the logic of `harfbuzz`.

The application works well in macOS. However, I haven't test it on Windows or Linux yet. I would give it a test on these platforms when I have time.

JetBrains Mono:
![Jetbrains](https://user-images.githubusercontent.com/33030965/146218804-dbf18842-b307-4c72-a314-024b8b970ba8.png)

Iosevka:
![Iosevka](https://user-images.githubusercontent.com/33030965/146218815-56c6b9f0-7da8-4d3e-8fbe-ac4236dee225.png)

Fira Code:
![Fira](https://user-images.githubusercontent.com/33030965/146218818-11c3257d-1631-402e-a29a-bc5ba583c9a4.png)