### PR TITLE
feat: Option to show a custom window title

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ The color can be `#RGB[A]` or `#RRGGBB[AA]`
 silicon ./target/test.rs -o test.png --background '#fff0'
 ```
 
+Show window title
+
+```bash
+silicon ./target/test.rs -o test.png --window-title "target/test.rs"
+```
+
 see `silicon --help` for detail
 
 ## Adding new syntaxes / themes

--- a/src/bin/silicon/config.rs
+++ b/src/bin/silicon/config.rs
@@ -150,6 +150,10 @@ pub struct Config {
     #[structopt(long)]
     pub no_window_controls: bool,
 
+    /// Show an optional window title
+    #[structopt(long, value_name = "WINDOW_TITLE")]
+    pub window_title: Option<String>,
+
     /// Hide the line number.
     #[structopt(long)]
     pub no_line_number: bool,
@@ -269,10 +273,10 @@ impl Config {
         let formatter = ImageFormatterBuilder::new()
             .line_pad(self.line_pad)
             .window_controls(!self.no_window_controls)
+            .window_title(self.window_title.clone())
             .line_number(!self.no_line_number)
             .font(self.font.clone().unwrap_or_default())
             .round_corner(!self.no_round_corner)
-            .window_controls(!self.no_window_controls)
             .shadow_adder(self.get_shadow_adder()?)
             .tab_width(self.tab_width)
             .highlight_lines(self.highlight_lines.clone().unwrap_or_default())

--- a/src/bin/silicon/config.rs
+++ b/src/bin/silicon/config.rs
@@ -150,7 +150,7 @@ pub struct Config {
     #[structopt(long)]
     pub no_window_controls: bool,
 
-    /// Show an optional window title
+    /// Show window title
     #[structopt(long, value_name = "WINDOW_TITLE")]
     pub window_title: Option<String>,
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -255,7 +255,7 @@ impl ImageFormatter {
 
         if self.window_title.is_some() {
             let title = self.window_title.as_ref().unwrap();
-            let title_width = self.font.get_text_len(&title);
+            let title_width = self.font.get_text_len(title);
 
             let ctrls_offset = if self.window_controls {
                 self.window_controls_width + self.title_bar_pad

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,8 +66,15 @@ impl ToRgba for syntect::highlighting::Color {
     }
 }
 
+pub struct WindowControlsParams {
+    pub width: u32,
+    pub height: u32,
+    pub padding: u32,
+    pub radius: u32,
+}
+
 /// Add the window controls for image
-pub(crate) fn add_window_controls(image: &mut DynamicImage) {
+pub(crate) fn add_window_controls(image: &mut DynamicImage, params: &WindowControlsParams) {
     let color = [
         ("#FF5F56", "#E0443E"),
         ("#FFBD2E", "#DEA123"),
@@ -77,27 +84,40 @@ pub(crate) fn add_window_controls(image: &mut DynamicImage) {
     let mut background = image.get_pixel(37, 37);
     background.0[3] = 0;
 
-    let mut title_bar = RgbaImage::from_pixel(120 * 3, 40 * 3, background);
+    let mut title_bar = RgbaImage::from_pixel(params.width * 3, params.height * 3, background);
+    let step = (params.radius * 2) as i32;
+    let spacer = (step * 2) as i32;
+    let center_y = (params.height / 2) as i32;
 
     for (i, (fill, outline)) in color.iter().enumerate() {
         draw_filled_circle_mut(
             &mut title_bar,
-            (((i * 40) as i32 + 20) * 3, 20 * 3),
-            11 * 3,
+            ((i as i32 * spacer + step) * 3, center_y * 3),
+            (params.radius + 1) as i32 * 3,
             outline.to_rgba().unwrap(),
         );
         draw_filled_circle_mut(
             &mut title_bar,
-            (((i * 40) as i32 + 20) * 3, 20 * 3),
-            10 * 3,
+            ((i as i32 * spacer + step) * 3, center_y * 3),
+            params.radius as i32 * 3,
             fill.to_rgba().unwrap(),
         );
     }
     // create a big image and resize it to blur the edge
     // it looks better than `blur()`
-    let title_bar = resize(&title_bar, 120, 40, FilterType::Triangle);
+    let title_bar = resize(
+        &title_bar,
+        params.width,
+        params.height,
+        FilterType::Triangle,
+    );
 
-    copy_alpha(&title_bar, image.as_mut_rgba8().unwrap(), 15, 15);
+    copy_alpha(
+        &title_bar,
+        image.as_mut_rgba8().unwrap(),
+        params.padding,
+        params.padding,
+    );
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Window title by passing a value to option `--window-title`:

```bash
silicon --from-clipboard -l rs --to-clipboard --window-title "src/bin/silicon/config.rs"
```

![image](https://user-images.githubusercontent.com/3720187/200200139-5a9b2890-f685-4ea7-8b76-11fb83624412.png)


closes #180 