### PR TITLE
Fixed a vague error message and updated copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Aloxaf
+Copyright (c) 2019-2023 Aloxaf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/bin/silicon/main.rs
+++ b/src/bin/silicon/main.rs
@@ -35,7 +35,7 @@ pub fn dump_image_to_clipboard(image: &DynamicImage) -> Result<(), Error> {
             temp.path().to_str().unwrap(),
         ])
         .status()
-        .map_err(|e| format_err!("Failed to copy image to clipboard: {}", e))?;
+        .map_err(|e| format_err!("Failed to copy image to clipboard : {} (Tip: do you have xclip installed ?)", e))?;
     Ok(())
 }
 


### PR DESCRIPTION
A commit fixes a vague error message for when people try to use the `--to-clipboard` option without xclip installed. 

The other commit updates the copyright year to 2023