### PR TITLE
Add missing Ubuntu dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install silicon
 ```bash
 sudo apt install expat
 sudo apt install libxml2-dev
-sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev libharfbuzz-dev
+sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev libharfbuzz-dev libfontconfig1-dev 
 ```
 
 ### Fedora

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install silicon
 ```bash
 sudo apt install expat
 sudo apt install libxml2-dev
-sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev libharfbuzz-dev libfontconfig1-dev 
+sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev libharfbuzz-dev libfontconfig1-dev g++ 
 ```
 
 ### Fedora


### PR DESCRIPTION
When installing on Ubuntu 22.04, Cargo's compilation fails when following the instructions outlined by the README.

```
# Install Rust & Cargo
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

# Required dependencies
sudo apt install expat
sudo apt install libxml2-dev
sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev libharfbuzz-dev

cargo install silicon
```

This provides the following panic message:
```
error: failed to run custom build command for `yeslogic-fontconfig-sys v3.2.0`

Caused by:
  process didn't exit successfully: `/tmp/cargo-installU4BB1g/release/build/yeslogic-fontconfig-sys-c86cf0f2ea856514/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN
  cargo:rerun-if-env-changed=FONTCONFIG_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=FONTCONFIG_STATIC
  cargo:rerun-if-env-changed=FONTCONFIG_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/yeslogic-fontconfig-sys-3.2.0/build.rs:8:48:
  called `Result::unwrap()` on an `Err` value: "\npkg-config exited with status code 1\n> PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags fontconfig\n\nThe system library `fontconfig` required by crate `yeslogic-fontconfig-sys` was not found.\nThe file `fontconfig.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.\nThe PKG_CONFIG_PATH environment variable is not set.\n\nHINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `fontconfig.pc`.\n"
```

This issue also occurred within the r-lib/systemfonts repository, and is solved by installing `libfontconfig1-dev` alongside the other dependencies. This should be added to the README since it's required for compilation to succeed.

The installation also had a variety of other errors that appear when starting from scratch, the first of which was that one of the dependencies was unable to find the `c++` command. This was easily solved by symlinking `gcc` to `c++`
```
sudo ln -s $(which gcc) "$(dirname $(which gcc))/c++"
```
Afterwards, there was *also* a linking error that I believe is either due to a missing / invalid LLVM installation, or some other issue that is unknown to me. I didn't investigate it further because I frankly didn't feel like digging into linking errors.
```
   ...
   Compiling clipboard v0.5.0
   Compiling shell-words v1.1.0
   Compiling silicon v0.5.2
error: linking with `cc` failed: exit status 1
 |
 = note: LC_ALL="C" PATH="/home/...
 # Huge block of file paths & other cli args
 ..."
 = note: /usr/bin/ld: cannot find -lstdc++: No such file or directory
         collect2: error: ld returned 1 exit status

error: could not compile `silicon` (bin "silicon") due to 1 previous error
```
Neither of the above issues appeared when I initially installed this in my WSL instance, but I suspect that this is because I already had the required installations as I am a developer. They did, however, appear within a minimal Ubuntu 22.04 Docker image, and a Ubuntu Server 22.04 virtual machine.
```
sudo docker pull ubuntu
sudo docker run -ti --rm ubuntu /bin/bash
```

Credit to the original comment: https://github.com/r-lib/systemfonts/issues/35#issuecomment-633560151