### PR TITLE
Feature: Added a code-right-pad option and fixed highlight-lines documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ EOF
 Highlight specified line
 
 ```bash
-silicon main.rs -o main.png --highlight-lines '1; 3-4'
+silicon main.rs -o main.png --highlight-lines '1;3-4'
 ```
 
 Custom the image

--- a/src/bin/silicon/config.rs
+++ b/src/bin/silicon/config.rs
@@ -114,7 +114,7 @@ pub struct Config {
     #[structopt(long, short, value_name = "FONT", parse(from_str = parse_font_str))]
     pub font: Option<FontList>,
 
-    /// Lines to high light. rg. '1-3; 4'
+    /// Lines to highlight. eg. '1-3;4'
     #[structopt(long, value_name = "LINES", parse(try_from_str = parse_line_range))]
     pub highlight_lines: Option<Lines>,
 
@@ -125,6 +125,10 @@ pub struct Config {
     /// Pad between lines
     #[structopt(long, value_name = "PAD", default_value = "2")]
     pub line_pad: u32,
+
+    /// Add PAD padding to the right of the code.
+    #[structopt(long, value_name = "PAD", default_value = "25")]
+    pub code_pad_right: u32,
 
     /// Line number offset
     #[structopt(long, value_name = "OFFSET", default_value = "1")]
@@ -281,7 +285,8 @@ impl Config {
             .shadow_adder(self.get_shadow_adder()?)
             .tab_width(self.tab_width)
             .highlight_lines(self.highlight_lines.clone().unwrap_or_default())
-            .line_offset(self.line_offset);
+            .line_offset(self.line_offset)
+            .code_pad_right(self.code_pad_right);
 
         Ok(formatter.build()?)
     }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -15,6 +15,9 @@ pub struct ImageFormatter<T> {
     /// pad of top of the code area
     /// Default: 50
     code_pad_top: u32,
+    /// pad of right of the code area
+    /// Default: 25
+    code_pad_right: u32,
     /// Title bar padding
     /// Default: 15
     title_bar_pad: u32,
@@ -57,6 +60,8 @@ pub struct ImageFormatter<T> {
 pub struct ImageFormatterBuilder<S> {
     /// Pad between lines
     line_pad: u32,
+    /// Padding to the right of the code 
+    code_pad_right: u32,
     /// Show line number
     line_number: bool,
     /// Font of english character, should be mono space font
@@ -106,6 +111,12 @@ impl<S: AsRef<str> + Default> ImageFormatterBuilder<S> {
     /// Set the pad between lines
     pub fn line_pad(mut self, pad: u32) -> Self {
         self.line_pad = pad;
+        self
+    }
+    
+    /// Set the pad on the right of the screen
+    pub fn code_pad_right(mut self, pad: u32) -> Self {
+        self.code_pad_right = pad;
         self
     }
 
@@ -164,6 +175,7 @@ impl<S: AsRef<str> + Default> ImageFormatterBuilder<S> {
             line_pad: self.line_pad,
             code_pad: 25,
             code_pad_top: if title_bar { 50 } else { 0 },
+            code_pad_right: self.code_pad_right,
             title_bar_pad: 15,
             window_controls: self.window_controls,
             window_controls_width: 120,
@@ -205,7 +217,7 @@ impl<T: TextLineDrawer> ImageFormatter<T> {
     /// calculate the size of code area
     fn get_image_size(&mut self, max_width: u32, lineno: u32) -> (u32, u32) {
         (
-            (max_width + self.code_pad).max(150),
+            (max_width + self.code_pad_right).max(150),
             self.get_line_y(lineno + 1) + self.code_pad,
         )
     }


### PR DESCRIPTION
This PR contains two changes. 

First, a small fix in the documentation for the `--highlight-lines` option, as can be seen here:

```
/// Lines to high light. rg. '1-3; 4'
```

But calling this with the suggested example,

```
$ silicon test.py --output test.png --highlight-lines '1-3; 4'
``` 

raises the following error:

```
error: Invalid value for '--highlight-lines <LINES>': invalid digit found in string
```

The proposed change fixes this by removing the space in the string. It also fixes some typos in the documentation comment.

The second change is regarding padding to the right of the code. Sometimes, the generated code screenshot feels somewhat "squished" to me. Here's an example of a C file I tried Silicon on just for fun. 

![image](https://github.com/Aloxaf/silicon/assets/122464874/bf2a2632-a78f-4f08-9878-6a3da9c307c8)

Here is the same code screenshot with the new `--code-pad-right` option set to `75` instead of the default `25`.

![image](https://github.com/Aloxaf/silicon/assets/122464874/29d3b256-c039-4bc9-9887-231cc45ed095)

It gives more of a gap on the right of the code, like how it is when normally editing code.