### PR TITLE
feat: using CLI input options to override configuration file settings

### DIFF
--- a/src/bin/silicon/main.rs
+++ b/src/bin/silicon/main.rs
@@ -105,7 +105,15 @@ fn run() -> Result<(), Error> {
     let mut args = get_args_from_config_file();
     let mut args_cli = std::env::args_os();
     args.insert(0, args_cli.next().unwrap());
-    args.extend(args_cli);
+
+    args_cli.into_iter().skip(0).for_each(|args_cli| {
+        if args.contains(&args_cli) {
+            let pos = args.iter().position(|x| x == &args_cli).unwrap();
+            args.drain(pos..pos + 2);
+        }
+        args.push(args_cli);
+    });
+
     let config: Config = Config::from_iter(args);
 
     let ha = HighlightingAssets::new();


### PR DESCRIPTION
Support using CLI input options to override configuration file settings, as shown below:

Configuration:
```
--font 'JetBrainsMonoNerdFont'
```

Bash Command:
```
silicon --font "Apple Color Emoji" -c example.py
```

Before this change, the bash command doesn't work and returns the error: The argument '--font <FONT>' was provided more than once.... After the fix, the command will take the CLI option as the first priority.