### PR TITLE
feat: Added option for custom image radius size

### DIFF
--- a/src/bin/silicon/config.rs
+++ b/src/bin/silicon/config.rs
@@ -167,6 +167,10 @@ pub struct Config {
     #[structopt(long)]
     pub no_round_corner: bool,
 
+    /// Set corner radius
+    #[structopt(long, default_value = "12")]
+    pub corner_radius: u8,
+
     /// Pad horiz
     #[structopt(long, value_name = "PAD", default_value = "80")]
     pub pad_horiz: u32,
@@ -282,6 +286,7 @@ impl Config {
             .line_number(!self.no_line_number)
             .font(self.font.clone().unwrap_or_default())
             .round_corner(!self.no_round_corner)
+            .corner_radius(self.corner_radius)
             .shadow_adder(self.get_shadow_adder()?)
             .tab_width(self.tab_width)
             .highlight_lines(self.highlight_lines.clone().unwrap_or_default())

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 use image::{Rgba, RgbaImage};
 use syntect::highlighting::{Color, Style, Theme};
 
-const MAX_RADIUS_RECOMMENDATION: u8 = 26;
-
 pub struct ImageFormatter<T> {
     /// pad between lines
     /// Default: 2
@@ -395,10 +393,10 @@ impl<T: TextLineDrawer> ImageFormatter<T> {
         }
 
         if self.round_corner && self.corner_radius != 0 {
-            if self.corner_radius > MAX_RADIUS_RECOMMENDATION {
+            if u32::from(self.corner_radius) > self.code_pad {
                 println!(
-                    "Warning: r = {} > {} (radius recommendation); Parts of the image may start to overlap!",
-                    self.corner_radius, MAX_RADIUS_RECOMMENDATION
+                    "Warning: r = {} > {} (code pad); Parts of the image may start to overlap!",
+                    self.corner_radius, self.code_pad
                 );
             }
             round_corner(&mut image, self.corner_radius.into());


### PR DESCRIPTION
* New argument --corner-radius
* If no value is provided defaults to 12 (previously hardcoded value)
* Warns if value is larger than MAX_RADIUS_RECOMMENDATION -> there may be some overlap a radius larger than 26
* If round_corner is set to false the value of corner_radius will be ignored
* Setting corner_radius to 0 is equivalent to setting round_corner to false